### PR TITLE
[왓챠챠챠] 프로필 페이지 API 구현

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from users.views import SignUpView, SignInView, WatchListView
+from users.views import SignUpView, SignInView, WatchListView, UserView
 urlpatterns = [
     path('/signup', SignUpView.as_view()),
     path('/signin', SignInView.as_view()),
     path('/watchlist', WatchListView.as_view()),
+    path('/profile', UserView.as_view()),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -5,5 +5,5 @@ urlpatterns = [
     path('/signup', SignUpView.as_view()),
     path('/signin', SignInView.as_view()),
     path('/watchlist', WatchListView.as_view()),
-    path('/profile', UserView.as_view()),
+    path('', UserView.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -6,9 +6,9 @@ from django.http            import JsonResponse
 from django.views           import View
 from django.core.exceptions import ValidationError
 from django.conf            import settings
-from django.db.models       import Sum, Avg
 
 from users.models     import User, WatchList
+from films.models     import Film
 from users.validation import (
     validate_username,
     validate_email,
@@ -16,7 +16,6 @@ from users.validation import (
     validate_birth
 )
 from core.utils       import token_decorator
-from films.models     import Film
 
 class SignUpView(View):
     def post(self, request):
@@ -103,3 +102,18 @@ class WatchListView(View):
             'image_url'        : film.image_url
         } for film in films]
         return JsonResponse({'results': results}, status=200)
+
+class UserView(View):
+    @token_decorator
+    def get(self, request):
+        try:
+            user = request.user
+
+            results = {
+                'username'        : user.username,
+                'watchlist_count' : user.watchlist_set.count(),
+            }
+            return JsonResponse({'results' : results})
+
+        except KeyError:
+            return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가

<br />

## :: 구현 목표
- 프로필 페이지에 필요한 API(닉네임, 보고 싶어요 개수) 구현

<br />

## :: 구현 사항 설명
1. 프로필 페이지에 필요한 API 정보들을 results에 묶어서 get
-username
-watchlist_count

<br />

## :: 성장 포인트
- count()를 이용한 총합을 구할 수 있다.
